### PR TITLE
Osm land fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,34 @@ curl -O http://planet.openstreetmap.org/pbf/planet-latest.osm.pbf
 ./imposm3 import -connection postgis://username:password@host/database-name -mapping imposm3.json -deployproduction
 ```
 
-## Import the Natural Earth dataset (requires gdal. can be skipped if you're only interested in OSM)
-Update the database credentials inside of `natural_earth.sh`, then run: `./natural_earth.sh`. This will download the natural earth dataset and insert it into PostGIS under a database named `natural_earth`. The script is idempotent.
+## Import the OSM Land and Natural Earth dataset (requires gdal, Natural Earth can be skipped if you're only interested in OSM)
 
-## Import the OSM land data set
-Update the database credentials inside of `osm_land.sh`, then run: `./osm_land.sh`. This will download the natural earth dataset and insert it into PostGIS under a database named `osm`.
+### Option 1: Embed Credentials
+Update the database credentials inside of `natural_earth.sh` and `osm_land.sh`, then run each file: `./natural_earth.sh && ./osm_land.sh`. This will download the natural earth and osm land datasets and insert it into PostGIS under a database named `natural_earth` and `osm` respectively.
+
+### Option 2: Create a dbcredentials.sh file
+Create a `dbcredentials.sh` file which will be shared with the `osm_land` script.  This option is ideal for when the `natural_earth` and `osm` databases will reside on the same database server, and will use the same credentials. Ensure that the following variables are defined in your file:
+```bash
+DB_HOST="mydbhost"
+DB_PORT="myport"
+DB_USER="myuser"
+DB_PW="mypassword"
+```
+Once you have configured the `dbcredentials.sh` file, run the scripts as above: `./natural_earth.sh && ./osm_land.sh`
+
+### Option 3:
+Create separate configuration files in the same pattern as the above `dbcredentials.sh` file and pass the path to the config file using the `-c` option.  This is ideal if you have two different servers for the databases. Ensure the file you create follows this format:
+```bash
+DB_NAME="mydb"
+DB_HOST="mydbhost"
+DB_PORT="myport"
+DB_USER="myuser"
+DB_PW="mypassword"
+```
+Once you have configured the files, run the scripts with the `-c` flag and provide the path to the credentials file, ie: `./natural_earth.sh -c natural_earth_creds.sh && ./osm_land.sh -c osm_creds.sh`
+
+### Usage:
+Both scripts support a `-v` flag for debugging.  `natural_earth.sh` also supports a `-d` flag, which will drop the existing natural earth database prior to import if set.  Since the `osm_land.sh` imports into a database shared with other data, it lacks this functionality.  Instead, only the relevent tables are dropped.
 
 ## Install SQL helper functions
 Execute `postgis_helpers.sql` against your OSM database. Currently this contains a single utility function for converting building heights from strings to numbers which is important if you want to extrude buildings for the 3d effect.

--- a/osm_land.sh
+++ b/osm_land.sh
@@ -18,6 +18,23 @@
 
 set -e
 
+CONFIG_FILE=''
+while getopts ":c:v" flag; do
+  case ${flag} in
+    c)
+      if [[ ! -r $OPTARG ]]; then echo "Config File $OPTARG Not Found!"; exit 2;
+      else echo "Using config file: $OPTARG"; CONFIG_FILE=$OPTARG
+      fi  ;;
+    v)
+      echo "Running in Verbose Mode"
+      set -x ;;
+    \?)
+      printf '\nUnrecognized option: -%s \nUsage: \n[-c file] Path to Config File \n[-v] verbose\n' $OPTARG; exit 2 ;;
+    :)
+      echo "Option -$OPTARG requires an argument"; exit 2 ;;
+  esac
+done
+
 # database connection variables
 DB_NAME="osm"
 DB_HOST=""
@@ -25,9 +42,9 @@ DB_PORT=""
 DB_USER=""
 DB_PW=""
 
-if [ -r dbcredentials.sh ]
-then
-	 source dbcredentials.sh
+# Check if we're using a config file
+if [[ -r $CONFIG_FILE ]]; then source $CONFIG_FILE
+elif [ -r dbcredentials.sh ]; then source dbcredentials.sh
 fi
 
 # check our connection string before we do any downloading

--- a/osm_land.sh
+++ b/osm_land.sh
@@ -38,7 +38,7 @@ psql "dbname='postgres' host='$DB_HOST' port='$DB_PORT' user='$DB_USER' password
 	"http://data.openstreetmapdata.com/land-polygons-split-3857.zip"
 )
 
- psql "dbname='postgres' host='$DB_HOST' port='$DB_PORT' user='$DB_USER' password='$DB_PW'" -c "DROP TABLE IF EXISTS land_polygons"
+psql "dbname='postgres' host='$DB_HOST' port='$DB_PORT' user='$DB_USER' password='$DB_PW'" -c "DROP TABLE IF EXISTS land_polygons"
 
 # iterate our dataurls
 for i in "${!dataurls[@]}"; do
@@ -53,7 +53,7 @@ for i in "${!dataurls[@]}"; do
 	echo $shape_file
 
 	# reproject data to webmercator (3857) and insert into our database
-	OGR_ENABLE_PARTIAL_REPROJECTION=true ogr2ogr -t_srs EPSG:3857 -nlt PROMOTE_TO_MULTI -f PostgreSQL PG:"dbname='$DB_NAME' host='$DB_HOST' port='$DB_PORT' user='$DB_USER' password='$DB_PW'" $shape_file
+	OGR_ENABLE_PARTIAL_REPROJECTION=true ogr2ogr -overwrite -t_srs EPSG:3857 -nlt PROMOTE_TO_MULTI -f PostgreSQL PG:"dbname='$DB_NAME' host='$DB_HOST' port='$DB_PORT' user='$DB_USER' password='$DB_PW'" $shape_file
 
 	# clean up
 	rm -rf $i/ $i.zip


### PR DESCRIPTION
Updates to the osm_land and natural_earth importer scripts to handle use cases as follows:
* Case where osm_land and natural_earth databases are stored on different servers, with different sets of `credentials.`
* Case where we do not have permissions to drop existing natural_earth database