### PR TITLE
Updated deprecated keys

### DIFF
--- a/imposm3.json
+++ b/imposm3.json
@@ -153,7 +153,7 @@
                     "key": null
                 },
                 {
-                    "type": "pseudoarea",
+                    "type": "area",
                     "name": "area",
                     "key": null
                 },
@@ -216,7 +216,7 @@
                     "key": null
                 },
                 {
-                    "type": "pseudoarea",
+                    "type": "area",
                     "name": "area",
                     "key": null
                 },
@@ -411,9 +411,11 @@
             ],
             "type": "linestring",
             "filters": {
-                "exclude_tags": [
-                    ["area", "yes"]
-                ]
+                "reject": {
+                    "area": [
+                      "yes"
+                    ]
+                  }
             },
             "mappings": {
 		"railway": {
@@ -734,7 +736,7 @@
                     "key": null
                 },
                 {
-                    "type": "pseudoarea",
+                    "type": "area",
                     "name": "area",
                     "key": null
                 },


### PR DESCRIPTION
"pseudoarea" and "exclude_tags" are deprecated.
I changed them to use up-to-date values.

"pseudoarea" is replaced by "area" and "exclude_tags" are replaced by "reject".