### PR TITLE
fix: drop table relative to db_name

### DIFF
--- a/osm_land.sh
+++ b/osm_land.sh
@@ -55,7 +55,7 @@ psql "dbname='postgres' host='$DB_HOST' port='$DB_PORT' user='$DB_USER' password
 	"https://osmdata.openstreetmap.de/download/land-polygons-split-3857.zip"
 )
 
-psql "dbname='postgres' host='$DB_HOST' port='$DB_PORT' user='$DB_USER' password='$DB_PW'" -c "DROP TABLE IF EXISTS land_polygons"
+psql "dbname='$DB_NAME' host='$DB_HOST' port='$DB_PORT' user='$DB_USER' password='$DB_PW'" -c "DROP TABLE IF EXISTS land_polygons"
 
 # iterate our dataurls
 for i in "${!dataurls[@]}"; do


### PR DESCRIPTION
First, thanks for all the work done. 

I found a small nit in the drop part for osm_land.sh.

The DROP TABLE should be done in the $DB_NAME and not default postgres database.